### PR TITLE
Allow solr handler to be specified when intializing Request::Standard

### DIFF
--- a/lib/solr/request/standard.rb
+++ b/lib/solr/request/standard.rb
@@ -13,10 +13,12 @@
 class Solr::Request::Standard < Solr::Request::Select
 
   VALID_PARAMS = [:query, :sort, :default_field, :operator, :start, :rows, :shards,
-    :filter_queries, :field_list, :debug_query, :explain_other, :facets, :highlighting, :mlt]
+    :filter_queries, :field_list, :debug_query, :explain_other, :facets, :highlighting, :mlt, :handler]
   
   def initialize(params)
-    super('standard')
+		# Check for handler option, pass in to Request::Select if present
+		@params[:handler] = params[:handler] || 'standard'
+    super(@params[:handler])
     
     raise "Invalid parameters: #{(params.keys - VALID_PARAMS).join(',')}" unless 
       (params.keys - VALID_PARAMS).empty?

--- a/lib/solr/request/standard.rb
+++ b/lib/solr/request/standard.rb
@@ -16,6 +16,8 @@ class Solr::Request::Standard < Solr::Request::Select
     :filter_queries, :field_list, :debug_query, :explain_other, :facets, :highlighting, :mlt, :handler]
   
   def initialize(params)
+    @params = params.dup
+
 		# Check for handler option, pass in to Request::Select if present
 		@params[:handler] = params[:handler] || 'standard'
     super(@params[:handler])
@@ -24,8 +26,7 @@ class Solr::Request::Standard < Solr::Request::Select
       (params.keys - VALID_PARAMS).empty?
     
     raise ":query parameter required" unless params[:query]
-    
-    @params = params.dup
+
     
     # Validate operator
     if params[:operator]


### PR DESCRIPTION
Previously Request::Standard always set the qt value as 'standard', now you can pass in a specific handler.

@connection.query('thing', :handler => 'my_handler')
